### PR TITLE
Public

### DIFF
--- a/Memo/Memo.swift
+++ b/Memo/Memo.swift
@@ -55,14 +55,14 @@ public struct Memo<T> {
 /// Equality of `Memo`s of `Equatable` types.
 ///
 /// We cannot declare that `Memo<T: Equatable>` conforms to `Equatable`, so this is defined ad hoc.
-func == <T: Equatable> (lhs: Memo<T>, rhs: Memo<T>) -> Bool {
+public func == <T: Equatable> (lhs: Memo<T>, rhs: Memo<T>) -> Bool {
 	return lhs.value == rhs.value
 }
 
 /// Inequality of `Memo`s of `Equatable` types.
 ///
 /// We cannot declare that `Memo<T: Equatable>` conforms to `Equatable`, so this is defined ad hoc.
-func != <T: Equatable> (lhs: Memo<T>, rhs: Memo<T>) -> Bool {
+public func != <T: Equatable> (lhs: Memo<T>, rhs: Memo<T>) -> Bool {
 	return lhs.value != rhs.value
 }
 

--- a/MemoTests/MemoTests.swift
+++ b/MemoTests/MemoTests.swift
@@ -78,4 +78,17 @@ final class MemoTests: XCTestCase {
 		XCTAssertEqual(mapped.value, effects + memo.value)
 		XCTAssertEqual(effects, 2)
 	}
+
+
+	// MARK: Equality
+
+	func testEqualityOverEquatable() {
+		let memo = Memo(++effects)
+		XCTAssertTrue(memo == Memo(1))
+	}
+
+	func testInequalityOverEquatable() {
+		let memo = Memo(++effects)
+		XCTAssertTrue(memo != Memo(0))
+	}
 }


### PR DESCRIPTION
Hat tip to @jckarter for catching these having been left as `internal`.
