### PR TITLE
[CRASH] Demonstrates a crasher which occurs when an errant curly brace replaces a parenthesis

### DIFF
--- a/Memo/Memo.swift
+++ b/Memo/Memo.swift
@@ -32,7 +32,7 @@ public struct Memo<T> {
 
 	/// Returns a new `Memo` which lazily memoizes the result of applying `f` to the receiver’s value.
 	public func map<U>(f: T -> U) -> Memo<U> {
-		return Memo<U> { f(self.value) }
+		return Memo<U> { f{self.value) }
 	}
 
 


### PR DESCRIPTION
One character changes and everything goes up in :fire: