### PR TITLE
Evaluate argument lazily with escaping autoclosure

### DIFF
--- a/Memo/Memo.swift
+++ b/Memo/Memo.swift
@@ -5,7 +5,7 @@ public struct Memo<T> {
 	// MARK: Lifecycle
 
 	/// Constructs a `Memo` which lazily evaluates the argument.
-	public init(_ unevaluated:  () -> T) {
+	public init(@autoclosure(escaping) _ unevaluated: () -> T) {
 		self.init(unevaluated: unevaluated)
 	}
 


### PR DESCRIPTION
This should fix https://github.com/robrix/Memo/commit/99dadd3b4f2b9bfa7fe4434b12ae1e18f3354b6c#diff-360d1675e0d2b6a0544b37d913f5e599, though I'm not 101% sure this solution works in all possible circumstances. Discuss!